### PR TITLE
fix regression in default encoding

### DIFF
--- a/transform/CMakeLists.txt
+++ b/transform/CMakeLists.txt
@@ -41,6 +41,7 @@ add_custom_command(OUTPUT ${WORK}/CosmicEval.js
   ${SRC}/cosmicos/Memory.hx
   ${SRC}/cosmicos/ManuscriptStyle.hx
   ${SRC}/cosmicos/CosFunction.hx
+  ${SRC}/cosmicos/BitString.hx
 )
 
 add_custom_command(OUTPUT ${WORK}/SpiderScrawl.js
@@ -138,6 +139,7 @@ add_custom_command(OUTPUT ${WORK}/primer.json
   DEPENDS ${WORK}/assem.json
   ${WORK}/CosmicEval.js
   ${CMAKE_SOURCE_DIR}/transform/assemble/primer.js)
+add_custom_target(primer ALL DEPENDS ${WORK}/primer.json)
 
 # assem2.json is assem.json but marked up also with message fragments
 # in final form

--- a/transform/cosmicos/Evaluate.hx
+++ b/transform/cosmicos/Evaluate.hx
@@ -25,14 +25,14 @@ class Evaluate {
                 }
                 return str;
             }
-            if (Std.is(e0,Int)||Std.is(e0,BigInteger)||Std.is(e0,BitString)) {
+            if (Std.is(e0,Int)||Std.is(e0,BigInteger)||Std.is(e0,BitString)||
+                Std.is(e0,String)) {
                 return e0;
             }
-            //trace("working on " + Parse.deconsify(e0));
             var cursor = new Cursor(e0);
             var x : Dynamic = evaluateInContext(cursor.next(),c);
             if (x==id_lambda) { // ?
-                var k2 : Int = evaluateInContext(cursor.next(),c);
+                var k2 : Dynamic = evaluateInContext(cursor.next(),c);
                 var e2 : Dynamic = cursor.next();
                 return function(v) {
                     var c2 = new Memory(c,k2,v);
@@ -184,7 +184,7 @@ class Evaluate {
     public function codifyLine(str: String) : String {
         var lst = Parse.stringToList(str,vocab);
         Parse.encodeSymbols(lst,vocab);
-        return Parse.codify(lst);
+        return Parse.codify(lst,vocab);
     }
 
     public function nestedLine(str: String) : Dynamic {
@@ -267,6 +267,10 @@ class Evaluate {
         vocab.check("div",34);
         vocab.check("primer",35);
         vocab.check("demo",36); // was 7
+
+        // start using longer codes for early symbols
+        vocab.set("is:int", 183);  //0b10110111
+        vocab.set("unary", 255);   //0b11111111
 
         mem.add(vocab.get("intro"), function(x){ return 1; });
         addStdMin();

--- a/transform/cosmicos/Memory.hx
+++ b/transform/cosmicos/Memory.hx
@@ -6,7 +6,7 @@ package cosmicos;
 class Memory {
     public var parent : Memory;
     public var block : Map<String,Dynamic>;
-    public var key : Int;
+    public var key : Dynamic;
     public var val : Dynamic;
 
     public function new(parent: Memory, key : Dynamic = -1, val : Dynamic = null) {

--- a/transform/cosmicos/Vocab.hx
+++ b/transform/cosmicos/Vocab.hx
@@ -21,6 +21,9 @@ class Vocab {
     public function getBase(name: String) : Int {
         if (name=="define") name = "@";
         if (!nameToCode.exists(name)) {
+            while (codeToName.exists(topCode)) {
+                topCode++;
+            }
             nameToCode.set(name,topCode);
             codeToName.set(topCode,name);
             topCode++;
@@ -30,7 +33,8 @@ class Vocab {
 
     public function get(name: String) : String {
         if (name=="define") name = "@";
-        return name; // switching from int coding to symbols.
+        getBase(name); // keep allocating ints for now
+        return name;
     }
 
     public function check(name: String, id : Int) : String {
@@ -38,6 +42,12 @@ class Vocab {
         if (id!=nid) {
             throw("id for " + name + " is unexpected (" + nid + " vs " + id + ")");
         }
+        return get(name);
+    }
+
+    public function set(name: String, id : Int) : String {
+        codeToName.set(id,name);
+        nameToCode.set(name,id);
         return get(name);
     }
 


### PR DESCRIPTION
As reported in #14 by @joha2, the default encoding of the message was broken in fe8f330.  This repairs the damage.  The intent of the breaking change had been to defer encoding of symbols as late as possible to make it easier to generate alternative versions of the message.