### PR TITLE
support message variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+language: haxe
 addons:
   apt:
     packages:
@@ -6,16 +7,8 @@ addons:
     - libbcel-java
     - openjdk-6-jdk
     - libgd-gd2-perl
-    - nodejs 
-    - ocaml
-    - camlp4
-    - neko
+    - nodejs
 script: 
-    - git clone --recursive git://github.com/HaxeFoundation/haxe.git
-    - cd haxe
-    - make
-    - sudo make install
-    - cd ..
     - mkdir build
     - cd build 
     - cmake ..

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ To build the message, type:
 You should find the message saved in your build directory 
 as `index.json` and `index.txt`.
 
+Compilation options
+-------------------
+
+There are options in how the message is built.  Run the cmake gui (`cmake-gui` or `ccmake` in Linux)
+and look for options starting with `COSMIC_`.
+
+ * `COSMIC_VARIANT` set to `default` - this currently assumes that symbols like `$` and `|` can be
+   somehow represented in the encoded message.
+ * `COSMIC_VARIANT` set to `nested` - this converts the `$` and `|` symbols to parentheses.
+ * `COSMIC_LINES` controls how many lines of the message are processed.  The default is 0, meaning
+   unlimited.
+
 Troubleshooting
 ---------------
 If you have compilation issues with `nodejs` similar to `node returned No such file or directory`, this can be resolved by symlinking it to `node`.  Another workaround is to install `nodejs-legacy`.

--- a/transform/CMakeLists.txt
+++ b/transform/CMakeLists.txt
@@ -35,13 +35,14 @@ add_custom_command(OUTPUT ${WORK}/CosmicEval.js
   COMMAND ${HAXE} -js CosmicEval.js -main cosmicos.Evaluate -cp ${SRC}
   WORKING_DIRECTORY ${WORK}
   DEPENDS 
+  ${SRC}/cosmicos/BitString.hx
+  ${SRC}/cosmicos/Config.hx
+  ${SRC}/cosmicos/CosFunction.hx
   ${SRC}/cosmicos/Evaluate.hx
+  ${SRC}/cosmicos/ManuscriptStyle.hx
+  ${SRC}/cosmicos/Memory.hx
   ${SRC}/cosmicos/Parse.hx
   ${SRC}/cosmicos/Vocab.hx
-  ${SRC}/cosmicos/Memory.hx
-  ${SRC}/cosmicos/ManuscriptStyle.hx
-  ${SRC}/cosmicos/CosFunction.hx
-  ${SRC}/cosmicos/BitString.hx
 )
 
 add_custom_command(OUTPUT ${WORK}/SpiderScrawl.js
@@ -68,8 +69,18 @@ add_custom_target(jshelpers ALL DEPENDS
 ## Add targets for message parts
 ##
 
-# we expect to get a variable COSMIC_DEPENDS that lists all parts
-include(${CMAKE_SOURCE_DIR}/src/README.cmake)
+set(COSMIC_VARIANT "default" CACHE STRING "Version of message to build")
+set(COSMIC_LINES "0" CACHE INT "Number of lines to process (0 for unlimited)")
+set_property(
+  CACHE COSMIC_VARIANT
+  PROPERTY STRINGS
+  "default" "nested" # should read this from variant directory once there
+                     # are more variants to support
+)
+# We expect to get these variables:
+#   COSMIC_DEPENDS that lists all parts
+#   COSMIC_USE_FLATTENER that controls whether '|' can be encoded
+include(${CMAKE_SOURCE_DIR}/variant/${COSMIC_VARIANT}.cmake)
 
 get_target_property(UnlessDriverLoc UnlessDriver JAR_FILE)
 get_target_property(FritzifierLoc Fritzifier JAR_FILE)
@@ -88,8 +99,8 @@ set(ACTIVE_DEPENDS)
 set(ACTIVE_DEPENDS_SHORT "")
 set(EXTRA_DEPEND_pl ${MSG}/cosmic.pm)
 set(EXTRA_DEPEND_js ${MSG}/cosmic.js)
-set(EXTRA_DEPEND_gate ${CMAKE_SOURCE_DIR}/bin/drawgate-ppm.pl ${CMAKE_SOURCE_DIR}/bin/drawgate-txt.pl ${UnlessDriverLoc})
-set(EXTRA_DEPEND_java ${FritzifierLoc})
+set(EXTRA_DEPEND_gate ${CMAKE_SOURCE_DIR}/bin/drawgate-ppm.pl ${CMAKE_SOURCE_DIR}/bin/drawgate-txt.pl UnlessDriver)
+set(EXTRA_DEPEND_java Fritzifier)
 foreach(depend ${COSMIC_DEPENDS})
   foreach(ext pl scm gate java js)
     if(EXISTS ${MSG}/${depend}.${ext})
@@ -107,6 +118,9 @@ foreach(depend ${COSMIC_DEPENDS})
     endif()
   endforeach()
 endforeach()
+
+set(COSMIC_OPTION_FILE ${WORK}/config.json)
+configure_file(config.json ${COSMIC_OPTION_FILE} @ONLY)
 
 # assem.txt contains a concatenation of all message parts, in
 # original textual form
@@ -223,4 +237,3 @@ add_custom_target(cli ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/cosh.js)
 ##
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/assemble/cosmicos ${CMAKE_BINARY_DIR}/bin/cosmsg.js @ONLY)
-

--- a/transform/config.json
+++ b/transform/config.json
@@ -1,0 +1,6 @@
+{
+    "variant": "@COSMIC_VARIANT@",
+    "use_flattener": @COSMIC_USE_FLATTENER@,
+    "lines": @COSMIC_LINES@
+}
+

--- a/transform/cosmicos/Config.hx
+++ b/transform/cosmicos/Config.hx
@@ -1,0 +1,38 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+package cosmicos;
+
+@:expose
+class Config {
+    private var config : Dynamic;
+
+    public function new(txt: String = null) {
+        config = null;
+        if (txt != null) {
+            config = haxe.Json.parse(txt);
+        }
+    }
+
+    /**
+     *
+     * Option: is flattener syntax "|" and "$" supported in the message or should
+     * these be mapped to parentheses.
+     *
+     */
+    public function useFlattener() : Bool {
+        if (config == null) return true;
+        return Reflect.field(config, 'use_flattener');
+    }
+
+    /**
+     *
+     *
+     * Number of lines of message to work on - 0 means unlimited.  Can be convenient
+     * to set to a small number during development.
+     *
+     */
+    public function lines() : Int {
+        if (config == null) return 0;
+        return Reflect.field(config, 'lines');
+    }
+}

--- a/transform/cosmicos/Evaluate.hx
+++ b/transform/cosmicos/Evaluate.hx
@@ -4,6 +4,7 @@ package cosmicos;
 
 @:expose
 class Evaluate {
+    private var config : Config;
     private var vocab : Vocab;
     private var mem : Memory;
     private var id_lambda : Dynamic;
@@ -181,6 +182,13 @@ class Evaluate {
         return lst;
     }
 
+    public function preprocessLine(str: String) : String {
+        if (!config.useFlattener()) {
+            str = Parse.removeFlatteningSyntax(str);
+        }
+        return str;
+    }
+
     public function codifyLine(str: String) : String {
         var lst = Parse.stringToList(str,vocab);
         Parse.encodeSymbols(lst,vocab);
@@ -194,7 +202,7 @@ class Evaluate {
         return lst;
     }
 
-    public function new() {
+    public function new(config: Config = null) {
         mem = new Memory(null);
         vocab = new Vocab();
         id_lambda = vocab.get("?");
@@ -203,6 +211,10 @@ class Evaluate {
         id_if = vocab.get("if");
         id_assign = vocab.get("assign");
         id_translate = -1;
+        this.config = config;
+        if (config == null) {
+            this.config = new Config();
+        }
     }
 
     static private function isBi(x:Dynamic) : Bool {

--- a/transform/cosmicos/Parse.hx
+++ b/transform/cosmicos/Parse.hx
@@ -132,7 +132,7 @@ class Parse {
     }
 
 
-    public static function preprocessString(x: String) : String {
+    public static function removeFlatteningSyntax(x: String) : String {
         var res = removePipes(x, 0); // start at level zero and remove | elements
         res = removeDollars(res); // transform $x into (x)
         return res;

--- a/variant/default.cmake
+++ b/variant/default.cmake
@@ -1,0 +1,6 @@
+# we expect to get a variable COSMIC_DEPENDS that lists all parts
+include(${CMAKE_SOURCE_DIR}/src/README.cmake)
+
+# Flag controlling whether the "|" symbol for flattening messages can be
+# encoded (if false), or (if false) should be expanded to nested parens.
+set(COSMIC_USE_FLATTENER true)

--- a/variant/nested.cmake
+++ b/variant/nested.cmake
@@ -1,0 +1,6 @@
+# we expect to get a variable COSMIC_DEPENDS that lists all parts
+include(${CMAKE_SOURCE_DIR}/src/README.cmake)
+
+# Flag controlling whether the "|" symbol for flattening messages can be
+# encoded (if true), or (if false) should be expanded to nested parens.
+set(COSMIC_USE_FLATTENER false)


### PR DESCRIPTION
This commit adds basic support for message variants.  Variants are placed in `variant/*.cmake` files.  Variants can include different sections of the message.  There is rudimentary support for encoding differences.  Currently the only option supported is whether the `|` and `$` syntax is considered to be syntactic sugar that needs expanding into parentheses, or genuine symbols to be communicated.