### PR TITLE
Message: removed "is"

### DIFF
--- a/msg/COS_Intro.js
+++ b/msg/COS_Intro.js
@@ -5,26 +5,25 @@ var cos = require("./cosmic");
 cos.language(2);
 
 cos.add("intro unary");
-cos.add("intro is");
-cos.add("intro int");
+cos.add("intro is-int");
 for (var i=0; i<16; i++) {
     var ones = "";
     for (var j=0; j<i; j++) {
 	ones += " 1";
     }
-    cos.add("is int | unary" + ones + " 0");
+    cos.add("is-int | unary" + ones + " 0");
 }
 
-cos.add("intro square");
+cos.add("intro is-square");
 for (var i=0; i<6; i++) {
     var ones = "";
     for (var j=0; j<i*i; j++) {
 	ones += " 1";
     }
-    cos.add("is square | unary" + ones + " 0");
+    cos.add("is-square | unary" + ones + " 0");
 }
 
-cos.add("intro prime");
+cos.add("intro is-prime");
 var primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31];
 for (var i=0; i<primes.length; i++) {
     var prime = primes[i];
@@ -32,5 +31,5 @@ for (var i=0; i<primes.length; i++) {
     for (var j=0; j<prime; j++) {
 	ones += " 1";
     }
-    cos.add("is prime | unary" + ones + " 0");
+    cos.add("is-prime | unary" + ones + " 0");
 }

--- a/msg/COS_Intro.js
+++ b/msg/COS_Intro.js
@@ -5,25 +5,25 @@ var cos = require("./cosmic");
 cos.language(2);
 
 cos.add("intro unary");
-cos.add("intro is-int");
+cos.add("intro is:int");
 for (var i=0; i<16; i++) {
     var ones = "";
     for (var j=0; j<i; j++) {
 	ones += " 1";
     }
-    cos.add("is-int | unary" + ones + " 0");
+    cos.add("is:int | unary" + ones + " 0");
 }
 
-cos.add("intro is-square");
+cos.add("intro is:square");
 for (var i=0; i<6; i++) {
     var ones = "";
     for (var j=0; j<i*i; j++) {
 	ones += " 1";
     }
-    cos.add("is-square | unary" + ones + " 0");
+    cos.add("is:square | unary" + ones + " 0");
 }
 
-cos.add("intro is-prime");
+cos.add("intro is:prime");
 var primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31];
 for (var i=0; i<primes.length; i++) {
     var prime = primes[i];
@@ -31,5 +31,5 @@ for (var i=0; i<primes.length; i++) {
     for (var j=0; j<prime; j++) {
 	ones += " 1";
     }
-    cos.add("is-prime | unary" + ones + " 0");
+    cos.add("is:prime | unary" + ones + " 0");
 }

--- a/msg/COS_Message.scm
+++ b/msg/COS_Message.scm
@@ -23,9 +23,9 @@
 
 # this line is referred to later - change/move carefully
 (equal (list-ref $primer 0) | vector intro unary);
-(equal (list-ref $primer 1) | vector intro is-int);
-(equal (list-ref $primer 2) | vector is-int | vector unary 0);
-(equal (list-ref $primer 3) | vector is-int | vector unary 1 0);
+(equal (list-ref $primer 1) | vector intro is:int);
+(equal (list-ref $primer 2) | vector is:int | vector unary 0);
+(equal (list-ref $primer 3) | vector is:int | vector unary 1 0);
 (assign idx (list:find $primer | vector intro primer) |
   equal (list-ref $primer | + $idx 1) |
     quote @@ | equal (list-ref $primer 0) | vector intro unary);

--- a/msg/COS_Message.scm
+++ b/msg/COS_Message.scm
@@ -23,10 +23,9 @@
 
 # this line is referred to later - change/move carefully
 (equal (list-ref $primer 0) | vector intro unary);
-(equal (list-ref $primer 1) | vector intro is);
-(equal (list-ref $primer 2) | vector intro int);
-(equal (list-ref $primer 3) | vector is int | vector unary 0);
-(equal (list-ref $primer 4) | vector is int | vector unary 1 0);
+(equal (list-ref $primer 1) | vector intro is-int);
+(equal (list-ref $primer 2) | vector is-int | vector unary 0);
+(equal (list-ref $primer 3) | vector is-int | vector unary 1 0);
 (assign idx (list:find $primer | vector intro primer) |
   equal (list-ref $primer | + $idx 1) |
     quote @@ | equal (list-ref $primer 0) | vector intro unary);

--- a/src/cosmicos/Evaluate.hx
+++ b/src/cosmicos/Evaluate.hx
@@ -390,24 +390,24 @@ class Evaluate {
         mem.add(vocab.get("i"), new Complex(0, 1));
 
         // Transition vocabulary
-        vocab.set("is-int", iid());
-        evaluateLine("@ is-int | ? x 1");  // should make this more precise
+        vocab.set("is:int", iid());
+        evaluateLine("@ is:int | ? x 1");  // should make this more precise
         vocab.set("unary-v", iid());
         evaluateLine("@ unary-v | ? v | ? x | if (= $x 0) $v (unary-v | + $v 1)");
         evaluateLine("@ unary | unary-v 0");
         // inefficient
         vocab.set("has-divisor-within", iid());
         evaluateLine("@ has-divisor-within | ? top | ? x | if (< $top 2) 0 | if (= $x | * $top | div $x $top) 1 | has-divisor-within (- $top 1) $x");
-        vocab.set("is-prime", iid());
-        evaluateLine("@ is-prime | ? x | if (< $x 2) 0 | not | has-divisor-within (- $x 1) $x");
+        vocab.set("is:prime", iid());
+        evaluateLine("@ is:prime | ? x | if (< $x 2) 0 | not | has-divisor-within (- $x 1) $x");
         // very very inefficient!        
         vocab.set("has-square-divisor-within", iid());
         evaluateLine("@ has-square-divisor-within | ? top | ? x | if (< $top 0) 0 | if (= $x | * $top $top) 1 | has-square-divisor-within (- $top 1) $x");
-        vocab.set("is-square", iid());
-        evaluateLine("@ is-square | ? x | has-square-divisor-within $x $x");
+        vocab.set("is:square", iid());
+        evaluateLine("@ is:square | ? x | has-square-divisor-within $x $x");
         evaluateLine("@ undefined 999999");  // this should be a special value, not 999999 :-)
         evaluateLine("@ even | ? x | = 0 | - $x | * 2 | div $x 2");
-        evaluateLine("@ is | ? x | if (= $x int) $is-int | if (= $x square) $is-square | if (= $x prime) $is-prime $undefined");
+        // evaluateLine("@ is | ? x | if (= $x int) $is:int | if (= $x square) $is:square | if (= $x prime) $is:prime $undefined");
 
         // meta-lambda-function
         id_lambda0 = vocab.get("??");


### PR DESCRIPTION
While looking at the first section and figuring out how to build an interpreter from scratch via Racket, I realized the `is` is somehow not useful and therefore I removed it. I had the following rationale:

- "is" is only used in first section.
- "is" leads to awkward syntax like `(is int (...))` where the semantics of "is" and "int" are not clear.
- Removal and introduction of `is-int`, `is-square`, `is-prime`
  simplifies syntax (`is int | unary 1 0` before vs. `is-int | unary 1 0` afterwards).
- The semantics of `is-int` is clear: it gets a number and outputs a bool
  and therefore leads to a statement with boolean value (should be true at top level of message).
- This is in line with the later statements, where e.g. comparisons take place.

Please tell me what you guys think.

Best wishes
Johannes